### PR TITLE
add StreamCopy to MediaMuxer.AddStream; add Remux sample

### DIFF
--- a/FFmpegWrapper.sln
+++ b/FFmpegWrapper.sln
@@ -23,6 +23,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Filtering", "Samples\Filter
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FFmpegWrapper.Tests", "FFmpegWrapper.Tests\FFmpegWrapper.Tests.csproj", "{19E971C2-414C-4102-9F5C-8D3B6C775580}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Remux", "Samples\Remux\Remux.csproj", "{6BA9A2DE-0E08-4810-B241-A4800719EDC7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -65,6 +67,10 @@ Global
 		{19E971C2-414C-4102-9F5C-8D3B6C775580}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{19E971C2-414C-4102-9F5C-8D3B6C775580}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{19E971C2-414C-4102-9F5C-8D3B6C775580}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6BA9A2DE-0E08-4810-B241-A4800719EDC7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6BA9A2DE-0E08-4810-B241-A4800719EDC7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6BA9A2DE-0E08-4810-B241-A4800719EDC7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6BA9A2DE-0E08-4810-B241-A4800719EDC7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -77,6 +83,7 @@ Global
 		{5017249E-A674-4958-9976-C9456E9A6C73} = {3D89B1B5-F184-4451-86F6-A05A52E261E4}
 		{76FF5717-BD7E-4267-95A0-4AF5F3D29B0A} = {3D89B1B5-F184-4451-86F6-A05A52E261E4}
 		{35992514-47D1-4F86-9298-CCC73163A0E1} = {3D89B1B5-F184-4451-86F6-A05A52E261E4}
+		{6BA9A2DE-0E08-4810-B241-A4800719EDC7} = {3D89B1B5-F184-4451-86F6-A05A52E261E4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FBB6A4C7-BCD6-45BD-A659-7BADD859E7D4}

--- a/FFmpegWrapper/MediaPacket.cs
+++ b/FFmpegWrapper/MediaPacket.cs
@@ -47,6 +47,12 @@ public unsafe class MediaPacket : FFObject
         set => _pkt->flags = value ? (_pkt->flags | ffmpeg.AV_PKT_FLAG_KEY) : (_pkt->flags & ~ffmpeg.AV_PKT_FLAG_KEY);
     }
 
+    /// <summary> byte position in stream, -1 if unknown. </summary>
+    public long BytePosition {
+        get => _pkt->pos;
+        set => _pkt->pos = value;
+    }
+
     public Span<byte> Data {
         get => new(_pkt->data, _pkt->size);
     }

--- a/Samples/Remux/Program.cs
+++ b/Samples/Remux/Program.cs
@@ -18,11 +18,9 @@ foreach (var srcStream in srcStreams) {
 remuxer.Open();
 
 using var packet = new MediaPacket();
-unsafe {
-    while (demuxer.Read(packet)) {
-        var index = packet.StreamIndex;
-        packet.RescaleTS(srcStreams[index].TimeBase, dstStreams[index].TimeBase);
-        packet.Handle->pos = -1;
-        remuxer.Write(packet);
-    }
+while (demuxer.Read(packet)) {
+    var index = packet.StreamIndex;
+    packet.RescaleTS(srcStreams[index].TimeBase, dstStreams[index].TimeBase);
+    packet.BytePosition = -1;
+    remuxer.Write(packet);
 }

--- a/Samples/Remux/Program.cs
+++ b/Samples/Remux/Program.cs
@@ -1,0 +1,28 @@
+﻿// https://github.com/FFmpeg/FFmpeg/blob/master/doc/examples/remux.c
+
+using FFmpeg.Wrapper;
+
+if (args.Length < 2) {
+    Console.WriteLine("Usage: Remux <input path> <output path.mkv>");
+    return;
+}
+
+using var demuxer = new MediaDemuxer(args[0]);
+using var remuxer = new MediaMuxer(args[1]);
+
+var srcStreams = demuxer.Streams.OrderBy(s => s.Index).ToArray();
+var dstStreams = new MediaStream[srcStreams.Length];
+foreach (var srcStream in srcStreams) {
+    dstStreams[srcStream.Index] = remuxer.AddStream(srcStream);
+}
+remuxer.Open();
+
+using var packet = new MediaPacket();
+unsafe {
+    while (demuxer.Read(packet)) {
+        var index = packet.StreamIndex;
+        packet.RescaleTS(srcStreams[index].TimeBase, dstStreams[index].TimeBase);
+        packet.Handle->pos = -1;
+        remuxer.Write(packet);
+    }
+}

--- a/Samples/Remux/Remux.csproj
+++ b/Samples/Remux/Remux.csproj
@@ -1,0 +1,5 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Hi @dubiousconst282 

In my project, I have some use case need to copy packet direct into Muxer, I think maybe better if this feature can be add in your code base

use cases:
- repair a mkv file'duration if muxer was not properly closed due to exception
- transcode only video frame, and level audio and subtitle stream unchanged
- truncate audio file

I am not sure if my implementation is well thought, I tested in my project and create a Remux sample. Feel free to change it up.

Best regards